### PR TITLE
fix calls to fpa for compatibility with fpa 0.5

### DIFF
--- a/CONSENT-correct
+++ b/CONSENT-correct
@@ -172,9 +172,9 @@ LRSCf=$(dirname $LRSCs)
 
 echo "["$(date)"] Self-aligning the long reads (minimap2)"
 if [[ $minimapOptions == "PB" ]] ; then
-	$LRSCf/minimap2/minimap2 --dual=yes -PD --no-long-join -w5 -g1000 -m30 -n1 -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa -i - -o $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
+	minimap2 --dual=yes -PD --no-long-join -w5 -g1000 -m30 -n1 -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa -i - -o $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
 else
-	$LRSCf/minimap2/minimap2 -k15 -w5 -m100 -g10000 -r2000 --max-chain-skip 25 --dual=yes -PD --no-long-join -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa -i - -o $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
+	minimap2 -k15 -w5 -m100 -g10000 -r2000 --max-chain-skip 25 --dual=yes -PD --no-long-join -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa -i - -o $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
 fi
 
 echo "["$(date)"] Correcting the long reads"

--- a/CONSENT-correct
+++ b/CONSENT-correct
@@ -172,9 +172,9 @@ LRSCf=$(dirname $LRSCs)
 
 echo "["$(date)"] Self-aligning the long reads (minimap2)"
 if [[ $minimapOptions == "PB" ]] ; then
-	$LRSCf/minimap2/minimap2 --dual=yes -PD --no-long-join -w5 -g1000 -m30 -n1 -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa - $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
+	$LRSCf/minimap2/minimap2 --dual=yes -PD --no-long-join -w5 -g1000 -m30 -n1 -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa -i - -o $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
 else
-	$LRSCf/minimap2/minimap2 -k15 -w5 -m100 -g10000 -r2000 --max-chain-skip 25 --dual=yes -PD --no-long-join -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa - $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
+	$LRSCf/minimap2/minimap2 -k15 -w5 -m100 -g10000 -r2000 --max-chain-skip 25 --dual=yes -PD --no-long-join -t"$nproc" -I"$minimapMemory" "$reads" "$reads" | fpa -i - -o $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
 fi
 
 echo "["$(date)"] Correcting the long reads"

--- a/CONSENT-polish
+++ b/CONSENT-polish
@@ -176,7 +176,7 @@ LRSCs=$(readlink -f "$0")
 LRSCf=$(dirname $LRSCs)
 
 echo "["$(date)"] Self-aligning the long reads (minimap2)"
-$LRSCf/minimap2/minimap2 --dual=yes -PD --no-long-join -w5 -g1000 -m30 -n1 -t"$nproc" -I"$minimapMemory" "$contigs" "$reads" > $tmpdir/"$alignments"
+minimap2 --dual=yes -PD --no-long-join -w5 -g1000 -m30 -n1 -t"$nproc" -I"$minimapMemory" "$contigs" "$reads" > $tmpdir/"$alignments"
 $LRSCf/bin/reformatPAF.py $tmpdir/"$alignments" > $tmpdir/"formatted_$alignments"
 fpa $tmpdir/"formatted_$alignments" $tmpdir/"$alignments" index -f $tmpdir/"$PAFIndex" -t query
 rm $tmpdir/"formatted_$alignments"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     rm Miniconda3-latest-Linux-x86_64.sh
 ENV PATH=/miniconda/bin:${PATH}
 RUN conda update -y conda
-RUN conda install -c bioconda fpa
-RUN ./install.sh
+RUN conda install -c bioconda fpa minimap2
+RUN cd BMEAN && ./install.sh && cd .. && make
 ENV PATH=/app/:${PATH}
 
 LABEL Name=CONSENT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:16.04
+
+# These commands copy your files into the specified directory in the image
+# and set that as the working location
+COPY . /app
+WORKDIR /app
+
+# Install fpa through conda
+RUN apt-get update && \
+    apt-get install -y curl make g++ zlib1g-dev && \
+    curl -LO https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh && \
+    bash Miniconda3-latest-Linux-x86_64.sh -p /miniconda -b && \
+    rm Miniconda3-latest-Linux-x86_64.sh
+ENV PATH=/miniconda/bin:${PATH}
+RUN conda update -y conda
+RUN conda install -c bioconda fpa
+RUN ./install.sh
+ENV PATH=/app/:${PATH}
+
+LABEL Name=CONSENT


### PR DESCRIPTION
Add -i and -o flags before input and output files in `fpa` calls, as specified in fpa 0.5 (commit [6193316](https://github.com/natir/fpa/commit/6193316ec3ef09e5ef0b4736ed5151a21743cc7d) )